### PR TITLE
ssh hostname correction

### DIFF
--- a/bih-cluster/docs/connecting/configure-ssh/linux.md
+++ b/bih-cluster/docs/connecting/configure-ssh/linux.md
@@ -184,7 +184,7 @@ Host mdcjail
 Now, do
 
 ```
-# ssh mdcjail ssh -A -t -l MDC_USER med-login<X>
+# ssh mdcjail ssh -A -t -l MDC_USER med-login<X>.bihealth.org
 ```
 
 * `<X>` can be either `1` or `2`


### PR DESCRIPTION
If you do not have med-login* in your /ssh/config (which is not part of this tutorial), you need to write the full host name.