### PR TITLE
Add portal logout tip to ondemand symlink creating

### DIFF
--- a/bih-cluster/docs/ondemand/interactive.md
+++ b/bih-cluster/docs/ondemand/interactive.md
@@ -64,6 +64,11 @@ $ ls -lhtr $HOME/ondemand/data/sys/dashboard/batch_connect/sys/ood-bih-rstudio-s
     $ ln -sr ~/work/ondemand ~/ondemand
     ```
 
+    Make sure to delete potential interactive sessions and to logout from the
+    Ondemand Portal first. Otherwise, the `~/ondemand` folder is constantly
+    recreated and the symlink will be just created within this folder as
+    `~/ondemand/ondemand` and thus not be used as intended.
+
     Also, clear out `~/work/ondemand/*` from time to time but take care that you don't remove the directory of any running job.
     
 

--- a/bih-cluster/docs/ondemand/overview.md
+++ b/bih-cluster/docs/ondemand/overview.md
@@ -84,6 +84,13 @@ res-login-1:~$ mv ~/ondemand ~/work/ondemand
 res-login-1:~$ ln -sr ~/work/ondemand ~/ondemand
 ```
 
+!!! important
+
+    Make sure to delete potential interactive sessions and to logout from the
+    Ondemand Portal first. Otherwise, the `~/ondemand` folder is constantly
+    recreated and the symlink will be just created within this folder as
+    `~/ondemand/ondemand` and thus not be used as intended.
+
 ## Portal Dashboard
 
 !!! help "Problems with Open OnDemand?"


### PR DESCRIPTION
Noticed that the `~/ondemand` folder is recreated after moving it to `~/work`. So I added a note on that you should delete interactive sessions and logout from the portal first.