### PR TITLE
Update cell-ranger.md

### DIFF
--- a/bih-cluster/docs/how-to/software/cell-ranger.md
+++ b/bih-cluster/docs/how-to/software/cell-ranger.md
@@ -61,6 +61,8 @@ add a file `slurm.template` to `/fast/users/$USER/work/cellranger-3.0.2/martian-
 __MRO_CMD__
 ```
 
+**note**: on newer cellranger version, `slurm.template` needs to go to `/fast/users/$USER/work/cellranger-XX/external/martian/jobmanagers/`
+
 # demultiplexing
 
 if that hasn't been done yet, you can use `cellranger mkfastq` (details to be added)

--- a/bih-cluster/docs/how-to/software/cell-ranger.md
+++ b/bih-cluster/docs/how-to/software/cell-ranger.md
@@ -11,7 +11,7 @@ requires registration before download from [here](https://support.10xgenomics.co
 to unpack Cell Ranger, its dependencies and the `cellranger` script:
 
 ```
-cd /fast/users/$USER/scratch
+cd /fast/users/$USER/work
 mv /path/to/cellranger-3.0.2.tar.gz .
 tar -xzvf cellranger-3.0.2.tar.gz
 ```
@@ -22,7 +22,7 @@ will be provided in `/fast/projects/cubit/current/static_data/app_support/cellra
 
 # cluster support SLURM
 
-add a file `slurm.template` to `/fast/users/$USER/scratch/cellranger-3.0.2/martian-cs/v3.2.0/jobmanagers/sge.template` with the following contents:
+add a file `slurm.template` to `/fast/users/$USER/work/cellranger-3.0.2/martian-cs/v3.2.0/jobmanagers/sge.template` with the following contents:
 
 ```
 #!/usr/bin/env bash
@@ -72,7 +72,7 @@ create a script `run_cellranger.sh` with these contents (consult the [documentat
 ```
 #!/bin/bash
 
-/fast/users/$USER/scratch/cellranger-3.0.2/cellranger count \
+/fast/users/$USER/work/cellranger-3.0.2/cellranger count \
   --id=sample_id \
   --transcriptome=/fast/projects/cubit/current/static_data/app_support/cellranger/refdata-cellranger-${species}-3.0.0\
   --fastqs=/path/to/fastqs \
@@ -91,7 +91,7 @@ sbatch --ntasks=1 --mem-per-cpu=4G --time=8:00:00 -p medium -o cellranger.log ru
 
 # cluster support SGE (outdated)
 
-add a file `sge.template` to `/fast/users/$USER/scratch/cellranger-3.0.2/martian-cs/v3.2.0/jobmanagers/sge.template` with the following contents:
+add a file `sge.template` to `/fast/users/$USER/work/cellranger-3.0.2/martian-cs/v3.2.0/jobmanagers/sge.template` with the following contents:
 
 ```
 # =============================================================================


### PR DESCRIPTION
docs recommended putting cellranger in `/fast/users/$USER/scratch` which is obviously stupid