### PR TITLE
Minor fixes in tutorial: double header, missing command

### DIFF
--- a/bih-cluster/docs/connecting/configure-ssh/prerequisites.md
+++ b/bih-cluster/docs/connecting/configure-ssh/prerequisites.md
@@ -22,7 +22,3 @@ The username for accessing the cluster is composed of your username at your prim
 
     - Access to the cluster is granted by BIH HPC IT through hpc-helpdesk@bih-charite.de
     - Access to the MDC jail node is managed by MDC IT
-
-### What is my username?
-
-You simply use your Charite user name!

--- a/bih-cluster/docs/first-steps/episode-0.md
+++ b/bih-cluster/docs/first-steps/episode-0.md
@@ -45,7 +45,7 @@ In preparation for our first steps tutorial series, we would like you to install
 In general the users on the cluster will manage their own software with the help of conda.
 If you haven't done so so far, please [follow the instructions in installing conda](../best-practice/software-installation-with-conda.md) first.
 The only premise is that you are able to [log into the cluster](../connecting/configure-ssh/linux.md).
-Make also sure that you are logged in to a computation node using ``.
+Make also sure that you are logged in to a computation node using `srun -p long --time 7-00 --mem=8G --ntasks=8 --pty bash -i`.
 
 Now we will create a new environment, so as to not interfere
 with your current or planned software stack, and install into it all the

--- a/bih-cluster/docs/first-steps/episode-0.md
+++ b/bih-cluster/docs/first-steps/episode-0.md
@@ -45,7 +45,7 @@ In preparation for our first steps tutorial series, we would like you to install
 In general the users on the cluster will manage their own software with the help of conda.
 If you haven't done so so far, please [follow the instructions in installing conda](../best-practice/software-installation-with-conda.md) first.
 The only premise is that you are able to [log into the cluster](../connecting/configure-ssh/linux.md).
-Make also sure that you are logged in to a computation node using `srun -p long --time 7-00 --mem=8G --ntasks=8 --pty bash -i`.
+Make also sure that you are logged in to a computation node using `srun -p medium --time 1-00 --mem=4G --ntasks=1 --pty bash -i`.
 
 Now we will create a new environment, so as to not interfere
 with your current or planned software stack, and install into it all the


### PR DESCRIPTION
- prerequisites.md had a double header with conflicting information. I've deleted the second header.

- episode-0 seems to intend to show a command to log into a computation node but this was left blank (``). I've added here the same command that was provided earlier in the tutorial.