### PR TITLE
made listing of conda environments more portable and not only limited…

### DIFF
--- a/bih-cluster/docs/storage/migration-faq.md
+++ b/bih-cluster/docs/storage/migration-faq.md
@@ -77,7 +77,7 @@ A simple solution we can recommend is this:
 1. Export all environments prior to the move with this bash script:
 ```sh
 #!/bin/bash
-for env in $(ls .miniforge/envs/)
+for env in $(ls $(conda info --base)/envs/)
 do
     conda env export -n $env -f $env.yml
 done


### PR DESCRIPTION
… to the miniforge distro

The previous listing of environments only works if they are in ~/miniforge, but they may be in ~/miniconda, ~/work/miniforge3 etc. conda info --base is slower, but more general.